### PR TITLE
Add error handling for namespace check

### DIFF
--- a/cmd/namespace-check/main.go
+++ b/cmd/namespace-check/main.go
@@ -60,8 +60,6 @@ func main() {
 	if reportErr != nil {
 		log.Fatalln("error reporting to kuberhealthy:", err.Error())
 	}
-
-	return
 }
 
 // doExpectedNamespacesExist checks if the expected namespaces exist in the cluster.

--- a/cmd/namespace-check/main.go
+++ b/cmd/namespace-check/main.go
@@ -72,9 +72,9 @@ func main() {
 				log.Fatalln("error reporting failure to kuberhealthy:", reportErr.Error())
 			}
 			return
-		} else {
-			log.Fatalln("Namespace not found by client, check failed:", err)
 		}
+	} else {
+		log.Fatalln("Namespace not found by client, check failed:", err)
 	}
 
 	if ok {

--- a/cmd/namespace-check/main_test.go
+++ b/cmd/namespace-check/main_test.go
@@ -7,53 +7,69 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
-
-func TestOptions_namespaceExist(t *testing.T) {
-	objects := getTestNamespaces()
-	namespaces = []string{"ns-01"}
-
-	tests := []struct {
-		name    string
-		want    bool
-		wantErr bool
-	}{
-		{
-			name:    "check ns-01 exists",
-			want:    true,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := testclient.NewSimpleClientset(objects...)
-			o := Options{
-				client: client,
-			}
-			got, err := o.namespaceExist(context.Background())
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Options.namespaceExist() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("Options.namespaceExist() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func getTestNamespaces() []runtime.Object {
 	return []runtime.Object{
 		&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns-01",
+				Name: "cert-manager",
 			},
 		},
 		&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "ns-02",
+				Name: "default",
 			},
 		},
+	}
+}
+
+func Test_doExpectedNamespacesExist(t *testing.T) {
+	type args struct {
+		ctx                context.Context
+		client             kubernetes.Interface
+		expectedNamespaces []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "The correct namespaces exist",
+			args: args{
+				ctx:                context.TODO(),
+				client:             testclient.NewSimpleClientset(getTestNamespaces()...),
+				expectedNamespaces: []string{"cert-manager", "default"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "The correct namespaces don't exist",
+			args: args{
+				ctx:                context.TODO(),
+				client:             testclient.NewSimpleClientset(getTestNamespaces()...),
+				expectedNamespaces: []string{"cert-manager", "default", "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Bad client",
+			args: args{
+				ctx:                context.TODO(),
+				client:             testclient.NewSimpleClientset(),
+				expectedNamespaces: []string{"cert-manager", "default"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := doExpectedNamespacesExist(tt.args.ctx, tt.args.client, tt.args.expectedNamespaces); (err != nil) != tt.wantErr {
+				t.Errorf("doExpectedNamespacesExist() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/cmd/namespace-check/main_test.go
+++ b/cmd/namespace-check/main_test.go
@@ -44,7 +44,6 @@ func TestOptions_namespaceExist(t *testing.T) {
 }
 
 func getTestNamespaces() []runtime.Object {
-
 	return []runtime.Object{
 		&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Every night we get an alertmanager alarm: ` KuberhealthyNamespaceExistsCheck` - it appears to be caused by a timeout, which is hard to diagnose.

If we receive an API response of not found, I think it would be beneficial to retry the check, as API calls have been known to fail.